### PR TITLE
Fix typos on italian translation

### DIFF
--- a/custom_components/silla_prism/translations/it.json
+++ b/custom_components/silla_prism/translations/it.json
@@ -21,7 +21,7 @@
                     "powerwall": "Abilita sensori per il Powerwall",
                     "maxcurr": "Corrente massima impostabile 6A-32A"
                 },
-                "description": "Inseire i dettagli della connessione al dispositivo",
+                "description": "Inserire i dettagli della connessione al dispositivo",
                 "title": "Configurazione Silla Prsim"
             }
         }
@@ -55,7 +55,7 @@
         },
         "select": {
             "set_port_mode": {
-                "name": "Imposta modlit\u00e0 porta",
+                "name": "Imposta modalit\u00e0 porta",
                 "state": {
                     "solar": "Solare",
                     "normal": "Normale",


### PR DESCRIPTION
While using (on a daily basis) the integration, I noticed some simple typos in the italian translation. This PR fixes them.